### PR TITLE
[Feat] Added dashboard for the CVE list and detail pages

### DIFF
--- a/app/cves/[id]/page.tsx
+++ b/app/cves/[id]/page.tsx
@@ -1,0 +1,108 @@
+import axios from "axios";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export default async function CVEDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const data = await axios.get(`${API_BASE_URL}/cves/${id}`);
+  const cve = data.data;
+
+  if (!cve)
+    return <p className="text-center text-lg text-gray-600">Loading...</p>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">{cve.id}</h1>
+      <p className="text-gray-700">
+        <strong>Description:</strong> {cve.descriptions?.[0]?.value || "N/A"}
+      </p>
+
+      <h2 className="text-xl font-semibold mt-4">CVSS V2 Metrics:</h2>
+      <p className="text-gray-700 mt-4">
+        <strong>Severity: </strong>
+        {cve.metrics?.[0]?.baseSeverity || "N/A"}
+      </p>
+      <p className="text-gray-700">
+        <strong>Score: </strong>
+        <span className="text-red-500 font-bold">
+          {cve.metrics?.[0]?.baseScore || "N/A"}
+        </span>
+      </p>
+      <p className="text-gray-700">
+        <strong>Vector String: </strong>
+        <span>{cve.metrics?.[0]?.vectorString || "N/A"}</span>
+      </p>
+
+      <h2 className="text-xl font-semibold mt-4">CVSS Details:</h2>
+      <table className="w-full border mt-2">
+        <thead>
+          <tr className="bg-gray-200">
+            <th className="p-2 border">Access Vector</th>
+            <th className="p-2 border">Access Complexity</th>
+            <th className="p-2 border">Authentication</th>
+            <th className="p-2 border">Confidentiality Impact</th>
+            <th className="p-2 border">Integrity Impact</th>
+            <th className="p-2 border">Availability Impact</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.accessVector || "N/A"}
+            </td>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.accessComplexity || "N/A"}
+            </td>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.authentication || "N/A"}
+            </td>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.confidentialityImpact || "N/A"}
+            </td>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.integrityImpact || "N/A"}
+            </td>
+            <td className="p-2 border">
+              {cve.metrics?.[0]?.availabilityImpact || "N/A"}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 className="text-xl font-semibold mt-4">Scores:</h2>
+
+      <p className="text-gray-700 mt-4">
+        Exploitability Score:{" "}
+        <strong>{cve.metrics?.[0]?.exploitabilityScore || "N/A"}</strong>
+      </p>
+      <p className="text-gray-700">
+        Impact Score: <strong>{cve.metrics?.[0]?.impactScore || "N/A"}</strong>
+      </p>
+
+      <h2 className="text-xl font-semibold mt-4">CPE:</h2>
+      <table className="w-full border mt-2">
+        <thead>
+          <tr className="bg-gray-200">
+            <th className="p-2 border">Criteria</th>
+            <th className="p-2 border">Match Criteria ID</th>
+            <th className="p-2 border">Vulnerable</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cve.configurations?.map((config, index) => (
+            <tr key={index} className={index % 2 === 0 ? "bg-gray-100" : ""}>
+              <td className="p-2 border">{config.criteria}</td>
+              <td className="p-2 border">{config.matchCriteriaId}</td>
+              <td className="p-2 border">{config.vulnerable ? "Yes" : "No"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/cves/list/page.tsx
+++ b/app/cves/list/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import axios from "axios";
+import Link from "next/link";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const CveListPage = () => {
+  const [cves, setCves] = useState([]);
+  const [totalRecords, setTotalRecords] = useState(0);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [sortBy, setSortBy] = useState("lastModifiedDate");
+  const [sortOrder, setSortOrder] = useState("DESC");
+
+  useEffect(() => {
+    fetchData();
+  }, [page, limit, sortBy, sortOrder]);
+
+  const fetchData = async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/cves/list`, {
+        params: { page, limit, sortBy, sortOrder },
+      });
+      setCves(response.data.data);
+      setTotalRecords(response.data.totalRecords);
+    } catch (error) {
+      console.error("Error fetching CVEs:", error);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-bold text-center mb-4">CVE LIST</h1>
+      <p className="text-gray-700">Total Records: {totalRecords}</p>
+
+      <div className="flex items-center space-x-4 mb-4 mt-4">
+        <label className="text-gray-700">Sort Order:</label>
+        <select
+          className="border p-2 rounded cursor-pointer"
+          onChange={(e) => setSortOrder(e.target.value)}
+          value={sortOrder}
+        >
+          <option value="ASC">ASC</option>
+          <option value="DESC">DESC</option>
+        </select>
+      </div>
+      <div className="flex items-center mb-4">
+        <div
+          className="p-2 border cursor-pointer"
+          onClick={() => setSortBy("publishedDate")}
+        >
+          Published Date{" "}
+          {sortBy === "publishedDate" && (sortOrder === "ASC" ? "⬆" : "⬇")}
+        </div>
+        <div
+          className="p-2 border cursor-pointer"
+          onClick={() => setSortBy("lastModifiedDate")}
+        >
+          Last Modified{" "}
+          {sortBy === "lastModifiedDate" && (sortOrder === "ASC" ? "⬆" : "⬇")}
+        </div>
+      </div>
+
+      <table className="w-full border border-gray-300 shadow-sm mt-4">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 border">CVE ID</th>
+            <th className="p-2 border">Identifier</th>
+            <th
+              className="p-2 border cursor-pointer"
+              onClick={() => setSortBy("publishedDate")}
+            >
+              Published Date ⬍
+            </th>
+            <th
+              className="p-2 border cursor-pointer"
+              onClick={() => setSortBy("lastModifiedDate")}
+            >
+              Last Modified ⬍
+            </th>
+            <th className="p-2 border">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cves.map((cve) => (
+            <tr key={cve.id} className="hover:bg-gray-100">
+              <td className="p-2 border">
+                <Link
+                  href={`/cves/${cve.id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  {cve.id}
+                </Link>
+              </td>
+              <td className="p-2 border">{cve.identifier}</td>
+              <td className="p-2 border">{cve.publishedDate}</td>
+              <td className="p-2 border">{cve.lastModifiedDate}</td>
+              <td className="p-2 border">{cve.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="flex mt-6 justify-between">
+        {/* Pagination & Results Per Page */}
+        <div className="flex justify-between items-center mt-4">
+          <div>
+            <label className="mr-2 text-gray-700">Results per page:</label>
+            <select
+              className="border p-2 rounded"
+              onChange={(e) => setLimit(Number(e.target.value))}
+              value={limit}
+            >
+              <option value={10}>10</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-center mt-6">
+          <span className="text-gray-700 mr-4">
+            {`${(page - 1) * limit + 1} - ${Math.min(
+              page * limit,
+              totalRecords
+            )} of ${totalRecords} records`}
+          </span>
+
+          <button
+            className={`px-3 py-1 border border-gray-400 rounded-l ${
+              page === 1
+                ? "bg-gray-300 cursor-not-allowed"
+                : "hover:bg-gray-400"
+            }`}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            ◀
+          </button>
+
+          {[...Array(5)].map((_, i) => {
+            const pageNum = page + i - 2; // Generate nearby pages
+            if (pageNum < 1 || pageNum > Math.ceil(totalRecords / limit))
+              return null;
+            return (
+              <button
+                key={pageNum}
+                onClick={() => setPage(pageNum)}
+                className={`px-3 py-1 border border-gray-400 ${
+                  pageNum === page
+                    ? "bg-white font-bold"
+                    : "bg-gray-300 hover:bg-gray-400"
+                }`}
+              >
+                {pageNum}
+              </button>
+            );
+          })}
+
+          <button
+            className={`px-3 py-1 border border-gray-400 rounded-r ${
+              page * limit >= totalRecords
+                ? "bg-gray-300 cursor-not-allowed"
+                : "hover:bg-gray-400"
+            }`}
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page * limit >= totalRecords}
+          >
+            ▶
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CveListPage;

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,3 +22,26 @@ body {
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+  text-align: center;
+}
+th,
+td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+th {
+  background-color: #f2f2f2;
+  cursor: pointer;
+}
+button {
+  cursor: pointer;
+}


### PR DESCRIPTION
### **📌 Summary**
Added dashboard for the CVE list and detail pages, along with global styling updates.

### **🛠️ Changes**
- **feat: add CVE list page**
  - Implemented `/cves/list` page to display CVE records.
  - Added sorting and pagination functionality.
  - Implemented "Results Per Page" selection (10, 50, 100).
  - Used Tailwind CSS for styling.
  
- **feat: add CVE detail page**
  - Implemented `/cves/[id]` page to display CVE details.
  - Fetched detailed data from the API and displayed structured metrics.
  - Included tables for CVSS V2 metrics and CPE configurations.
  
- **feat: update global styles**
  - Updated global styles for better UI consistency.
  - Improved table styling and interactive elements.

### **🔍 How to Test**
1. Run the application and navigate to `/cves/list`.
2. Verify that the CVE list loads correctly with pagination and sorting.
3. Click on a CVE ID to navigate to `/cves/[id]` and check if detailed information is displayed properly.
4. Test different "Results Per Page" options and ensure correct API calls are made.
5. Validate that the global styles apply correctly across the pages.

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/74b377e2-2c8b-4c02-bf64-30f8d39561d9" />
<img width="894" alt="image" src="https://github.com/user-attachments/assets/7d660c76-73b4-4a61-86e1-f8e5190254a9" />
