### PR TITLE
[Feat] Preserve CVE List State Across Navigation

### DIFF
--- a/app/cves/[id]/page.tsx
+++ b/app/cves/[id]/page.tsx
@@ -1,23 +1,43 @@
-import { Cve } from "@/app/types/cve";
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
 import axios from "axios";
+import { Cve } from "@/app/types/cve";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export default async function CVEDetailPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
+const CVEDetailPage = () => {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [cve, setCve] = useState<Cve | null>(null);
 
-  const data = await axios.get(`${API_BASE_URL}/cves/${id}`);
-  const cve: Cve = data.data;
+  useEffect(() => {
+    fetchData();
+  }, [id]);
 
-  if (!cve)
-    return <p className="text-center text-lg text-gray-600">Loading...</p>;
+  const fetchData = async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/cves/${id}`);
+      console.log("response", response);
+      setCve(response.data);
+    } catch (error) {
+      console.error("Error fetching CVE data:", error);
+    }
+  };
 
-  return (
+  const handleBack = () => {
+    router.back(); // Go back while keeping query parameters
+  };
+
+  return cve ? (
     <div className="max-w-4xl mx-auto p-6">
+      <button
+        onClick={handleBack}
+        className="text-blue-600 hover:underline mb-4"
+      >
+        ← Back to List
+      </button>
       <h1 className="text-2xl font-bold mb-4">{cve.id}</h1>
       <p className="text-gray-700">
         <strong>Description:</strong> {cve.descriptions?.[0]?.value || "N/A"}
@@ -105,5 +125,9 @@ export default async function CVEDetailPage({
         </tbody>
       </table>
     </div>
+  ) : (
+    <div>Loading...</div>
   );
-}
+};
+
+export default CVEDetailPage;

--- a/app/cves/list/page.tsx
+++ b/app/cves/list/page.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import Link from "next/link";
 import { Cve } from "@/app/types/cve";
+import { usePathname, useSearchParams } from "next/navigation";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 const CveListPage = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const limit = Number(searchParams.get("limit")) || 10;
+  const sortBy = searchParams.get("sortBy") || "lastModifiedDate";
+  const sortOrder = searchParams.get("sortOrder") || "DESC";
+
   const [cves, setCves] = useState<Cve[]>([]);
   const [totalRecords, setTotalRecords] = useState(0);
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(10);
-  const [sortBy, setSortBy] = useState("lastModifiedDate");
-  const [sortOrder, setSortOrder] = useState("DESC");
 
   useEffect(() => {
     fetchData();
@@ -31,6 +35,15 @@ const CveListPage = () => {
     }
   };
 
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+      return params.toString();
+    },
+    [searchParams]
+  );
+
   return (
     <div className="max-w-5xl mx-auto p-6">
       <h1 className="text-2xl font-bold text-center mb-4">CVE LIST</h1>
@@ -38,30 +51,45 @@ const CveListPage = () => {
 
       <div className="flex items-center space-x-4 mb-4 mt-4">
         <label className="text-gray-700">Sort Order:</label>
-        <select
-          className="border p-2 rounded cursor-pointer"
-          onChange={(e) => setSortOrder(e.target.value)}
-          value={sortOrder}
+        <Link
+          className={`border p-2 rounded cursor-pointer hover:bg-gray-400 ${
+            sortOrder === "ASC" ? "bg-gray-500 text-white" : ""
+          }`}
+          href={pathname + "?" + createQueryString("sortOrder", "ASC")}
         >
-          <option value="ASC">ASC</option>
-          <option value="DESC">DESC</option>
-        </select>
+          ASC
+        </Link>
+        <Link
+          className={`border p-2 rounded cursor-pointer hover:bg-gray-400 ${
+            sortOrder === "DESC" ? "bg-gray-500 text-white" : ""
+          }`}
+          href={pathname + "?" + createQueryString("sortOrder", "DESC")}
+        >
+          DESC
+        </Link>
       </div>
+
       <div className="flex items-center mb-4">
-        <div
-          className="p-2 border cursor-pointer"
-          onClick={() => setSortBy("publishedDate")}
+        <Link
+          className={`p-2 border cursor-pointer hover:bg-gray-400 ${
+            sortBy === "publishedDate" ? "bg-gray-300" : ""
+          }`}
+          href={pathname + "?" + createQueryString("sortBy", "publishedDate")}
         >
           Published Date{" "}
           {sortBy === "publishedDate" && (sortOrder === "ASC" ? "⬆" : "⬇")}
-        </div>
-        <div
-          className="p-2 border cursor-pointer"
-          onClick={() => setSortBy("lastModifiedDate")}
+        </Link>
+        <Link
+          className={`p-2 border cursor-pointer hover:bg-gray-400 ${
+            sortBy === "lastModifiedDate" ? "bg-gray-300" : ""
+          }`}
+          href={
+            pathname + "?" + createQueryString("sortBy", "lastModifiedDate")
+          }
         >
           Last Modified{" "}
           {sortBy === "lastModifiedDate" && (sortOrder === "ASC" ? "⬆" : "⬇")}
-        </div>
+        </Link>
       </div>
 
       <table className="w-full border border-gray-300 shadow-sm mt-4">
@@ -69,18 +97,8 @@ const CveListPage = () => {
           <tr className="bg-gray-100">
             <th className="p-2 border">CVE ID</th>
             <th className="p-2 border">Identifier</th>
-            <th
-              className="p-2 border cursor-pointer"
-              onClick={() => setSortBy("publishedDate")}
-            >
-              Published Date ⬍
-            </th>
-            <th
-              className="p-2 border cursor-pointer"
-              onClick={() => setSortBy("lastModifiedDate")}
-            >
-              Last Modified ⬍
-            </th>
+            <th className="p-2 border">Published Date</th>
+            <th className="p-2 border">Last Modified</th>
             <th className="p-2 border">Status</th>
           </tr>
         </thead>
@@ -89,7 +107,10 @@ const CveListPage = () => {
             <tr key={cve.id} className="hover:bg-gray-100">
               <td className="p-2 border">
                 <Link
-                  href={`/cves/${cve.id}`}
+                  href={{
+                    pathname: `/cves/${cve.id}`,
+                    query: { page, limit, sortBy, sortOrder },
+                  }}
                   className="text-blue-600 hover:underline"
                 >
                   {cve.id}
@@ -105,20 +126,32 @@ const CveListPage = () => {
       </table>
 
       <div className="flex mt-6 justify-between">
-        {/* Pagination & Results Per Page */}
-        <div className="flex justify-between items-center mt-4">
-          <div>
-            <label className="mr-2 text-gray-700">Results per page:</label>
-            <select
-              className="border p-2 rounded"
-              onChange={(e) => setLimit(Number(e.target.value))}
-              value={limit}
-            >
-              <option value={10}>10</option>
-              <option value={50}>50</option>
-              <option value={100}>100</option>
-            </select>
-          </div>
+        <div className="flex items-center space-x-2">
+          <label className="mr-2 text-gray-700">Results per page:</label>
+          <Link
+            className={`border p-2 rounded cursor-pointer hover:bg-gray-400 ${
+              limit === 10 ? "bg-gray-500 text-white" : ""
+            }`}
+            href={pathname + "?" + createQueryString("limit", "10")}
+          >
+            10
+          </Link>
+          <Link
+            className={`border p-2 rounded cursor-pointer hover:bg-gray-400 ${
+              limit === 50 ? "bg-gray-500 text-white" : ""
+            }`}
+            href={pathname + "?" + createQueryString("limit", "50")}
+          >
+            50
+          </Link>
+          <Link
+            className={`border p-2 rounded cursor-pointer hover:bg-gray-400 ${
+              limit === 100 ? "bg-gray-500 text-white" : ""
+            }`}
+            href={pathname + "?" + createQueryString("limit", "100")}
+          >
+            100
+          </Link>
         </div>
 
         <div className="flex items-center justify-center mt-6">
@@ -129,26 +162,29 @@ const CveListPage = () => {
             )} of ${totalRecords} records`}
           </span>
 
-          <button
+          <Link
             className={`px-3 py-1 border border-gray-400 rounded-l ${
               page === 1
                 ? "bg-gray-300 cursor-not-allowed"
                 : "hover:bg-gray-400"
             }`}
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={page === 1}
+            href={
+              pathname + "?" + createQueryString("page", (page - 1).toString())
+            }
           >
             ◀
-          </button>
+          </Link>
 
           {[...Array(5)].map((_, i) => {
-            const pageNum = page + i - 2; // Generate nearby pages
+            const pageNum = page + i - 2;
             if (pageNum < 1 || pageNum > Math.ceil(totalRecords / limit))
               return null;
             return (
-              <button
+              <Link
                 key={pageNum}
-                onClick={() => setPage(pageNum)}
+                href={
+                  pathname + "?" + createQueryString("page", pageNum.toString())
+                }
                 className={`px-3 py-1 border border-gray-400 ${
                   pageNum === page
                     ? "bg-white font-bold"
@@ -156,21 +192,22 @@ const CveListPage = () => {
                 }`}
               >
                 {pageNum}
-              </button>
+              </Link>
             );
           })}
 
-          <button
+          <Link
             className={`px-3 py-1 border border-gray-400 rounded-r ${
               page * limit >= totalRecords
                 ? "bg-gray-300 cursor-not-allowed"
                 : "hover:bg-gray-400"
             }`}
-            onClick={() => setPage((p) => p + 1)}
-            disabled={page * limit >= totalRecords}
+            href={
+              pathname + "?" + createQueryString("page", (page + 1).toString())
+            }
           >
             ▶
-          </button>
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Ensures pagination, sorting, and results per page remain consistent when navigating between CVE list and detail pages.
- Uses Next.js Link components instead of buttons to update query parameters in the URL.
- Improves user experience by preventing resets when returning to the list.

### **🛠️ Changes**
- Modified `app/cves/list/page.tsx` to read and update query parameters.
- Updated `app/cves/[id]/page.tsx` to include a back button that retains query params.
- Applied consistent query-based state management.

## Testing
- Navigated between list and detail pages to confirm state persistence.
- Verified pagination, sorting, and limit selection remain unchanged after navigating.


